### PR TITLE
Use explicit `use` for `napi` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,7 @@
 #![deny(clippy::all)]
 
-#[macro_use]
-extern crate napi_derive;
-
 use napi::bindgen_prelude::*;
+use napi_derive::napi;
 
 #[napi]
 fn v4() -> String {


### PR DESCRIPTION
Since the 2018 edition there is no need to use `macro_use` and
`extern crate` for importing macros, and `use napi_derive::napi` makes a
great sense for newcomers to understand where does this macro come from.

See https://twitter.com/TheEhsanSarshar/status/1443947323818717186
for an example of the confusion :)

Overall, I think this simple change simplifies the code even more!
